### PR TITLE
TOK-135 Refactor the build_mint_txn_handler

### DIFF
--- a/libsovtoken/src/api/mod.rs
+++ b/libsovtoken/src/api/mod.rs
@@ -13,14 +13,13 @@ use indy::ErrorCode;
 use logic::add_request_fees;
 use logic::build_payment;
 use logic::indy_sdk_api::crypto_api::CryptoSdk;
+use logic::minting;
 use logic::payments::{CreatePaymentHandler};
 
 use logic::fees::Fees;
-use logic::output::OutputConfig;
 
 use logic::config::{
     payment_config::{PaymentRequest},
-    output_mint_config::{MintRequest},
     payment_address_config::{PaymentAddressConfig},
     set_fees_config::{SetFeesRequest, SetFeesConfig},
     get_fees_config::GetFeesRequest,
@@ -34,7 +33,7 @@ use logic::parsers::{
     parse_get_txn_fees::parse_fees_from_get_txn_fees_response
 };
 
-use utils::ffi_support::{str_from_char_ptr, cstring_from_str, string_from_char_ptr, deserialize_from_char_ptr, c_pointer_from_string};
+use utils::ffi_support::{str_from_char_ptr, cstring_from_str, string_from_char_ptr, c_pointer_from_string};
 use utils::json_conversion::{JsonDeserialize, JsonSerialize};
 use utils::general::ResultExtension;
 use utils::general::{validate_did_len};
@@ -47,7 +46,8 @@ use utils::general::{validate_did_len};
     err:  results.
     json_pointer: results data.  format is defined by the API
 */
-type JsonCallback = Option<extern fn(command_handle: i32, err: i32, json_pointer: *const c_char) -> i32>;
+pub type JsonCallback = Option<JsonCallbackUnwrapped>;
+pub type JsonCallbackUnwrapped =  extern fn(command_handle: i32, err: i32, json_pointer: *const c_char) -> i32;
 
 /// This method generates private part of payment address
 /// and stores it in a secure place. It should be a
@@ -741,7 +741,30 @@ pub extern "C" fn parse_get_txn_fees_response_handler(command_handle: i32,
 }
 
 
-/// Builds a Mint Request to mint tokens
+/**
+ * Build a mint transaction request.
+ * 
+ * A mint transaction will need to be signed by a quorum of trustees.
+ * 
+ * The mint transaction can only be used once.
+ * 
+ * ## Parameters
+ * 
+ * ### DID (Decentralized Identifier)
+ * 
+ * ### outputs_json
+ * ```JSON
+ * {
+ *      "ver": <int>
+ *      "outputs": [
+ *          {
+ *              "address": <str: payment_address>,
+ *              "amount": <int>
+ *              "extra": <str>
+ *          }
+ *      ]
+ * }
+ */
 #[no_mangle]
 pub extern "C" fn build_mint_txn_handler(
     command_handle:i32,
@@ -750,22 +773,24 @@ pub extern "C" fn build_mint_txn_handler(
     outputs_json: *const c_char,
     cb: JsonCallback) -> i32
 {
-
-    let handle_result = api_result_handler!(< *const c_char >, command_handle, cb);
-    let submitter_did = string_from_char_ptr(submitter_did);
-    if cb.is_none() {
-        return handle_result(Err(ErrorCode::CommonInvalidStructure)) as i32;
-    }
-
-    let outputs_config = match deserialize_from_char_ptr::<OutputConfig>(outputs_json) {
-        Ok(c) => c,
-        Err(e) => return handle_result(Err(e)) as i32
+    let (did, outputs, cb) = match minting::deserialize_inputs(
+        submitter_did,
+        outputs_json,
+        cb
+    ) {
+        Ok(tup) => tup,
+        Err(e) => return e as i32,
     };
+    trace!("Deserialized build_mint_txn_handler arguments.");
 
-    let mint_request = MintRequest::from_config(outputs_config, submitter_did.unwrap());
-    let mint_request = mint_request.serialize_to_cstring().unwrap();
+    let mint_request = match minting::build_mint_request(did, outputs) {
+        Ok(json) => json,
+        Err(e) => return e as i32
+    };
+    trace!("Serialized mint request as pointer.");
 
-    return handle_result(Ok(mint_request.as_ptr())) as i32;
+    cb(command_handle, ErrorCode::Success as i32, mint_request);
+    return ErrorCode::Success as i32;
 }
 
 /**

--- a/libsovtoken/src/logic/minting.rs
+++ b/libsovtoken/src/logic/minting.rs
@@ -1,0 +1,182 @@
+use api::{JsonCallback, JsonCallbackUnwrapped};
+use indy::ErrorCode;
+use libc::c_char;
+use logic::address;
+use logic::output::{OutputConfig};
+use logic::config::output_mint_config::MintRequest;
+use serde_json;
+use utils::ffi_support::{string_from_char_ptr};
+use utils::general::validate_did_len;
+
+type DeserializedArguments = (String, OutputConfig, JsonCallbackUnwrapped);
+
+pub fn deserialize_inputs(
+    did: *const c_char,
+    outputs_json: *const c_char,
+    cb: JsonCallback
+) -> Result<DeserializedArguments, ErrorCode> {
+    let cb = cb.ok_or(ErrorCode::CommonInvalidStructure)?;
+    trace!("Unwrapped callback.");
+
+    let did = string_from_char_ptr(did)
+        .ok_or(ErrorCode::CommonInvalidStructure)?;
+    debug!("Converted did pointer to string >>> {:?}", did);
+
+    if ! validate_did_len(&did) {
+        return Err(ErrorCode::CommonInvalidStructure);
+    }
+    trace!("Validated did length.");
+
+    let outputs_json = string_from_char_ptr(outputs_json)
+        .ok_or(ErrorCode::CommonInvalidStructure)?;
+    debug!("Converted outputs_json pointer to string >>> {:?}", outputs_json);
+
+    let output_config: OutputConfig = serde_json::from_str(&outputs_json)
+        .or(Err(ErrorCode::CommonInvalidStructure))?;
+    debug!("Deserialized output_json >>> {:?}", output_config);
+
+    return Ok((did, output_config, cb));
+}
+
+pub fn build_mint_request(
+    did: String,
+    mut output_config: OutputConfig
+) -> Result<*const c_char, ErrorCode> {
+
+    for output in &mut output_config.outputs {
+        let address = address::verkey_checksum_from_address(output.address.clone())?;
+        output.address = address;
+    }
+    trace!("Stripped pay:sov: from outputs");
+
+    let mint_request = MintRequest::from_config(output_config, did);
+    debug!("Built a mint request >>> {:?}", mint_request);
+
+    return mint_request.serialize_to_pointer()
+        .or(Err(ErrorCode::CommonInvalidStructure));
+}
+
+#[cfg(test)]
+mod test_build_mint_request {
+    use utils::constants::txn_types::MINT_PUBLIC;
+    use utils::ffi_support::{c_pointer_from_string, c_pointer_from_str};
+    use logic::output::Output;
+    use super::*;
+    
+    #[test]
+    fn build_mint_request_invalid_address() {
+        let output_config = OutputConfig {
+            ver: 1,
+            outputs: vec![
+                Output::new(String::from("pad:sov:ql33nBkjGw6szxPT6LLRUIejn9TZAYkVRPd0QJzfJ8FdhZWs"), 12, None)
+            ]
+        };
+
+        let did = String::from("en32ansFeZNERIouv2xA");
+        let result = build_mint_request(did, output_config);
+        assert_eq!(ErrorCode::CommonInvalidStructure, result.unwrap_err());
+    }
+
+    #[test]
+    fn build_mint_request_valid() {
+        let output_config_value = json!({
+            "ver": 1,
+            "outputs": [{
+                "address": "pay:sov:ql33nBkjGw6szxPT6LLRUIejn9TZAYkVRPd0QJzfJ8FdhZWs",
+                "amount": 12
+            }]
+        });
+
+        let did = c_pointer_from_str("en32ansFeZNERIouv2xAo");
+        let (did, output_config, _) = test_deserialize_inputs::call_deserialize_inputs(
+            Some(did),
+            Some(c_pointer_from_string(output_config_value.to_string())),
+            None
+        ).unwrap();
+
+        let result = build_mint_request(did, output_config).unwrap();
+        let mint_request_json = string_from_char_ptr(result).unwrap();
+        let mint_value: serde_json::value::Value = serde_json::from_str(&mint_request_json).unwrap();
+
+        let expected = json!({
+            "identifier": "en32ansFeZNERIouv2xAo",
+            "operation": {
+                "type": MINT_PUBLIC,
+                "outputs": [
+                    ["ql33nBkjGw6szxPT6LLRUIejn9TZAYkVRPd0QJzfJ8FdhZWs", 12]
+                ]
+            },
+        });
+
+        assert_eq!(expected.get("operation"), mint_value.get("operation"));
+        assert_eq!(expected.get("identifier"), mint_value.get("identifier"));
+    }
+}
+
+#[cfg(test)]
+mod test_deserialize_inputs {
+    use super::*;
+    use std::ptr;
+    use utils::default;
+    use utils::ffi_support::{c_pointer_from_str, c_pointer_from_string};
+
+
+    pub fn call_deserialize_inputs(
+        did: Option<*const c_char>,
+        outputs_json: Option<*const c_char>,
+        cb: Option<JsonCallback>
+    ) -> Result<DeserializedArguments, ErrorCode> {
+        let req_json = did.unwrap_or_else(default::did);
+        let outputs_json = outputs_json.unwrap_or_else(default::outputs_json_pointer);
+        let cb = cb.unwrap_or(Some(default::empty_callback_string));
+
+        return deserialize_inputs(req_json, outputs_json, cb);
+    }
+
+    #[test]
+    fn deserialize_empty_did() {
+        let result = call_deserialize_inputs(Some(ptr::null()), None, None);
+        assert_eq!(ErrorCode::CommonInvalidStructure, result.unwrap_err());
+    }
+
+    #[test]
+    fn deserialize_empty_outputs() {
+        let result = call_deserialize_inputs(None, Some(ptr::null()), None);
+        assert_eq!(ErrorCode::CommonInvalidStructure, result.unwrap_err());
+    }
+
+    #[test]
+    fn deserialize_empty_callback() {
+        let result = call_deserialize_inputs(None, None, Some(None));
+        assert_eq!(ErrorCode::CommonInvalidStructure, result.unwrap_err());
+    }
+
+    #[test]
+    fn deserialize_did_invalid_length() {
+        let did = c_pointer_from_str("MyFakeDidWithALengthThatIsTooLong");
+        let result = call_deserialize_inputs(Some(did), None, None);
+        assert_eq!(ErrorCode::CommonInvalidStructure, result.unwrap_err());
+    }
+
+    #[test]
+    fn deserialize_outputs_invalid_structure() {
+        // Invalid because there is no ver field.
+        let outputs = c_pointer_from_string(json!({
+            "outputs": [
+                {
+                    "address": "pay:sov:ql33nBkjGw6szxPT6LLRUIejn9TZAYkVRPd0QJzfJ8FdhZWs",
+                    "amount": 10
+                }
+            ]
+        }).to_string());
+        let result = call_deserialize_inputs(None, Some(outputs), None);
+        assert_eq!(ErrorCode::CommonInvalidStructure, result.unwrap_err());
+    }
+
+    #[test]
+    fn deserialize_valid_arguments() {
+        let result = call_deserialize_inputs(None, None, None);
+        assert!(result.is_ok());
+    }
+
+}

--- a/libsovtoken/src/logic/mod.rs
+++ b/libsovtoken/src/logic/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod indy_sdk_api;
 pub mod input;
 pub mod output;
+pub mod minting;
 pub mod payments;
 pub mod parsers;
 pub mod request;

--- a/libsovtoken/src/logic/request.rs
+++ b/libsovtoken/src/logic/request.rs
@@ -1,11 +1,12 @@
 use std::ffi::CString;
-use utils::ffi_support::cstring_from_str;
+use libc::c_char;
+use utils::ffi_support::{cstring_from_str, c_pointer_from_string};
 use utils::random::rand_req_id;
 use serde::Serialize;
 use serde_json;
 use utils::json_conversion::JsonSerialize;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Request<T>
     where T: Serialize
@@ -30,7 +31,16 @@ impl<T> Request<T>
     }
 
     pub fn serialize_to_cstring(&self) -> Result<CString, serde_json::Error> {
-        let serialized = JsonSerialize::to_json(&self)?;
-        return Ok(cstring_from_str(serialized));
+        return self.serialize_to_string()
+            .map(|string| cstring_from_str(string));
+    }
+
+    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
+        return JsonSerialize::to_json(&self);
+    }
+
+    pub fn serialize_to_pointer(&self) -> Result<*const c_char, serde_json::Error> {
+        return self.serialize_to_string()
+            .map(|string| c_pointer_from_string(string));
     }
 }

--- a/libsovtoken/src/utils/default.rs
+++ b/libsovtoken/src/utils/default.rs
@@ -5,6 +5,7 @@
 
 use libc::c_char;
 use utils::ffi_support::c_pointer_from_string;
+use utils::random::rand_string;
 
 pub fn inputs_json_pointer() -> *const c_char {
     let json = json!({
@@ -45,4 +46,9 @@ pub extern fn empty_callback_string(
     _: *const c_char
 ) -> i32 {
     return e;
+}
+
+pub fn did() -> *const c_char {
+    let did = rand_string(21);
+    return c_pointer_from_string(did);
 }

--- a/libsovtoken/tests/build_mint_txn_handler_test.rs
+++ b/libsovtoken/tests/build_mint_txn_handler_test.rs
@@ -18,7 +18,7 @@ use sovtoken::utils::ffi_support::{str_from_char_ptr, c_pointer_from_str};
 
 const COMMAND_HANDLE:i32 = 10;
 static INVALID_OUTPUT_JSON: &'static str = r#"{"totally" : "Not a Number", "bobby" : "DROP ALL TABLES"}"#;
-static VALID_OUTPUT_JSON: &'static str = r#"{"ver":1,"outputs":[["AesjahdahudgaiuNotARealAKeyygigfuigraiudgfasfhja",10]]}"#;
+static VALID_OUTPUT_JSON: &'static str = r#"{"ver":1,"outputs":[["pay:sov:ql33nBkjGw6szxPT6LLRUIejn9TZAYkVRPd0QJzfJ8FdhZWs",10]]}"#;
 
 // ***** UNIT TESTS ****
 
@@ -79,20 +79,23 @@ fn valid_output_json() {
 
         let expected = json!({
             "type": "10000",
-            "outputs": [["AesjahdahudgaiuNotARealAKeyygigfuigraiudgfasfhja",10]]
+            "outputs": [["ql33nBkjGw6szxPT6LLRUIejn9TZAYkVRPd0QJzfJ8FdhZWs",10]]
         });
         assert_eq!(mint_operation, &expected);
         return ErrorCode::Success as i32;
     }
-    let did = r#"857297582y4672jdsjk822323242342332"#;
-    let did = c_pointer_from_str(did);
+
+    let did = c_pointer_from_str("857297582y4672jdsjk8l");
     let outputs_str = CString::new(VALID_OUTPUT_JSON).unwrap();
     let outputs_str_ptr = outputs_str.as_ptr();
-    let return_error = sovtoken::api::build_mint_txn_handler(COMMAND_HANDLE,
-                                                             1,
-                                                             did,
-                                                             outputs_str_ptr,
-                                                             Some(valid_output_json_cb));
+    let return_error = sovtoken::api::build_mint_txn_handler(
+        COMMAND_HANDLE,
+        1,
+        did,
+        outputs_str_ptr,
+        Some(valid_output_json_cb)
+    );
+                                                            
     assert_eq!(return_error, ErrorCode::Success as i32, "Expecting Valid JSON for 'build_mint_txn_handler'");
     unsafe {
         assert!(CALLBACK_CALLED);


### PR DESCRIPTION
- Conform to current async behavior.

- Removed unwraps and use good deserialization error handling.

- Strip pay:sov: from addresses.

- Validate the did≥