### PR TITLE
CM-2251 Hide PII information from logs.

### DIFF
--- a/libsovtoken/src/api/mod.rs
+++ b/libsovtoken/src/api/mod.rs
@@ -189,7 +189,7 @@ pub extern "C" fn add_request_fees_handler(
     cb: JsonCallback
 ) -> i32 {
 
-    trace!("api::add_request_fees_handler called did (address) >> {:?}", did);
+    trace!("api::add_request_fees_handler called did (address) >> {:?}", secret!(&did));
     let (inputs, outputs, extra, request_json_map, cb) = match add_request_fees::deserialize_inputs(req_json, inputs_json, outputs_json, extra, cb) {
         Ok(tup) => tup,
         Err(error_code) => {
@@ -357,7 +357,7 @@ pub extern "C" fn build_payment_req_handler(
     extra: *const c_char,
     cb: JsonCallback
 ) -> i32 {
-    trace!("api::build_payment_req_handler called >> submitter_did (address) {:?}", submitter_did);
+    trace!("api::build_payment_req_handler called >> submitter_did (address) {:?}", secret!(&submitter_did));
     let (inputs, outputs, extra, cb) = match build_payment::deserialize_inputs(inputs_json, outputs_json, extra, cb) {
         Ok(tup) => tup,
         Err(error_code) => {
@@ -479,7 +479,7 @@ pub extern "C" fn build_get_utxo_request_handler(command_handle: i32,
             return ErrorCode::CommonInvalidStructure as i32;
         }
     };
-    debug!("api::build_get_utxo_request_handler >> wallet_handle: {:?}, payment_address: {:?}", wallet_handle, payment_address);
+    debug!("api::build_get_utxo_request_handler >> wallet_handle: {:?}, payment_address: {:?}", wallet_handle, secret!(&payment_address));
 
     let utxo_request =
         GetUtxoOperationRequest::new(String::from(payment_address));
@@ -656,7 +656,7 @@ pub extern "C" fn build_get_txn_fees_handler(
         did.validate().map_err(map_err_trace!()).or(Err(ErrorCode::CommonInvalidStructure))
     });
 
-    debug!("api::build_get_txn_fees_handler >> wallet_handle: {:?}, submitter_did: {:?}", wallet_handle, did);
+    debug!("api::build_get_txn_fees_handler >> wallet_handle: {:?}, submitter_did: {:?}", wallet_handle, secret!(&did));
 
     let did = match opt_res_to_res_opt!(did) {
         Ok(did) => did,

--- a/libsovtoken/src/logic/api_internals/add_request_fees.rs
+++ b/libsovtoken/src/logic/api_internals/add_request_fees.rs
@@ -29,32 +29,32 @@ pub fn deserialize_inputs (
     extra: *const c_char,
     cb: Option<AddRequestFeesCb>
 ) -> Result<DeserializedArguments, ErrorCode> {
-    debug!("logic::add_request_fees::deserialize_inputs >> req_json: {:?}, inputs_json: {:?}, outputs_json: {:?}", req_json, inputs_json, outputs_json);
+    debug!("logic::add_request_fees::deserialize_inputs >> req_json: {:?}, inputs_json: {:?}, outputs_json: {:?}", secret!(&req_json), secret!(&inputs_json), secret!(&outputs_json));
 
     let cb = cb.ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
 
     let request_json = string_from_char_ptr(req_json).ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
-    debug!("Converted request_json pointer into string >>> {:?}", request_json);
+    debug!("Converted request_json pointer into string >>> {:?}", secret!(&request_json));
 
     let inputs_json = string_from_char_ptr(inputs_json).ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
-    debug!("Converted inputs_json pointer to string >>> {:?}", inputs_json);
+    debug!("Converted inputs_json pointer to string >>> {:?}", secret!(&inputs_json));
 
     let outputs_json = string_from_char_ptr(outputs_json).ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
-    debug!("Converted outputs_json pointer to string >>> {:?}", outputs_json);
+    debug!("Converted outputs_json pointer to string >>> {:?}", secret!(&outputs_json));
 
     let extra = string_from_char_ptr(extra);
     debug!("Converted extra pointer to string >>> {:?}", extra);
 
     let inputs: Inputs = serde_json::from_str(&inputs_json).map_err(map_err_err!()).or(Err(ErrorCode::CommonInvalidStructure))?;
-    debug!("Deserialized input_json >>> {:?}", inputs);
+    debug!("Deserialized input_json >>> {:?}", secret!(&inputs));
 
     let outputs: Outputs = serde_json::from_str(&outputs_json).map_err(map_err_err!()).or(Err(ErrorCode::CommonInvalidStructure))?;
-    debug!("Deserialized output_json >>> {:?}", outputs);
+    debug!("Deserialized output_json >>> {:?}", secret!(&outputs));
 
     let extra: Option<Extra> = if let Some(extra_) = extra {
         serde_json::from_str(&extra_).map_err(map_err_err!()).or(Err(ErrorCode::CommonInvalidStructure))?
     } else { None };
-    debug!("Deserialized extra >>> {:?}", extra);
+    debug!("Deserialized extra >>> {:?}", secret!(&extra));
 
     let request_json_object: serde_json::Value = serde_json::from_str(&request_json).map_err(map_err_err!()).or(Err(ErrorCode::CommonInvalidStructure))?;
     trace!("Converted request_json to serde::json::Value");
@@ -62,7 +62,7 @@ pub fn deserialize_inputs (
     let request_json_map = request_json_object.as_object().ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
     trace!("Converted request_json to hash_map");
 
-    debug!("Deserialized values: inputs: {:?}, outputs: {:?}, request_json_map: {:?}", inputs, outputs, request_json_map);
+    debug!("Deserialized values: inputs: {:?}, outputs: {:?}, request_json_map: {:?}", secret!(&inputs), secret!(&outputs), secret!(&request_json_map));
     return Ok((
         inputs,
         outputs,
@@ -97,7 +97,7 @@ pub fn add_fees_to_request_and_serialize(
     request_json_map: SerdeMap,
     cb: Box<Fn(Result<String, ErrorCode>) + Send + Sync>
 ) -> Result<(), ErrorCode> {
-    trace!("logic::add_request_fees::add_fees_to_request_and_serialize >> wallet_handle: {:?}, inputs: {:?}, outputs: {:?}, request_json_map: {:?}", wallet_handle, inputs, outputs, request_json_map);
+    trace!("logic::add_request_fees::add_fees_to_request_and_serialize >> wallet_handle: {:?}, inputs: {:?}, outputs: {:?}, request_json_map: {:?}", wallet_handle, secret!(&inputs), secret!(&outputs), secret!(&request_json_map));
     let res = add_fees(wallet_handle, inputs, outputs, extra, request_json_map, Box::new(move |request_json_map_updated|{
         let rm_fees = request_json_map_updated.map(|request_json_map_with_fees| serialize_request_with_fees(request_json_map_with_fees));
         match rm_fees {
@@ -152,7 +152,7 @@ fn add_fees(wallet_handle: i32, inputs: Inputs, outputs: Outputs, extra: Option<
 }
 
 fn serialize_request_with_fees(request_json_map_with_fees: SerdeMap) -> Result<String, ErrorCode> {
-    trace!("fee_map: {:?}", request_json_map_with_fees);
+    trace!("fee_map: {:?}", secret!(&request_json_map_with_fees));
     let serialized_request_with_fees = serde_json::to_string(&json!(request_json_map_with_fees))
         .or(Err(ErrorCode::CommonInvalidStructure))?;
     trace!("Serialized request_with_fees");

--- a/libsovtoken/src/logic/api_internals/create_address.rs
+++ b/libsovtoken/src/logic/api_internals/create_address.rs
@@ -29,14 +29,14 @@ pub fn deserialize_arguments(
         .ok_or(ErrorCode::CommonInvalidStructure)
         .map_err(map_err_err!())?;
 
-    debug!("api::create_payment_address_handler json_config_string >> {:?}", json_config_string);
+    debug!("api::create_payment_address_handler json_config_string >> {:?}", secret!(&json_config_string));
 
     // TODO: Only continue when seed is missing, not on any error.
     let config = PaymentAddressConfig::from_json(&json_config_string)
         .map_err(map_err_trace!())
         .unwrap_or(PaymentAddressConfig { seed: "".to_string() });
 
-    debug!("api::create_payment_address_handler PaymentAddressConfig >> {:?}", config);
+    debug!("api::create_payment_address_handler PaymentAddressConfig >> {:?}", secret!(&config));
 
     Ok((config, cb))
 }
@@ -52,7 +52,7 @@ pub fn create_address_cb(command_handle: i32, cb: JsonCallbackUnwrapped) -> impl
             return;
         }
 
-        debug!("create_payment_address_handler returning payment address of '{}'", &payment_address);
+        debug!("create_payment_address_handler returning payment address of '{}'", secret!(&payment_address));
         let payment_address_cstring = cstring_from_str(payment_address);
         let payment_address_ptr = payment_address_cstring.as_ptr();
 

--- a/libsovtoken/src/logic/build_payment.rs
+++ b/libsovtoken/src/logic/build_payment.rs
@@ -22,24 +22,24 @@ pub fn deserialize_inputs(
     extra: *const c_char,
     cb: Option<BuildPaymentRequestCb>
 ) -> Result<DeserializedArguments, ErrorCode> {
-    trace!("logic::build_payment::deserialize_inputs >> inputs_json: {:?}, outputs_json: {:?}, extra: {:?}", inputs_json, outputs_json, extra);
+    trace!("logic::build_payment::deserialize_inputs >> inputs_json: {:?}, outputs_json: {:?}, extra: {:?}", secret!(&inputs_json), secret!(&outputs_json), secret!(&extra));
     let cb = cb.ok_or(ErrorCode::CommonInvalidStructure)?;
 
     let inputs_json = string_from_char_ptr(inputs_json)
         .ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
-    debug!("Converted inputs_json pointer to string >>> {:?}", inputs_json);
+    debug!("Converted inputs_json pointer to string >>> {:?}", secret!(&inputs_json));
 
     let outputs_json = string_from_char_ptr(outputs_json)
         .ok_or(ErrorCode::CommonInvalidStructure).map_err(map_err_err!())?;
-    debug!("Converted outputs_json pointer to string >>> {:?}", outputs_json);
+    debug!("Converted outputs_json pointer to string >>> {:?}", secret!(&outputs_json));
 
     let inputs: Inputs = serde_json::from_str(&inputs_json).map_err(map_err_err!())
         .or(Err(ErrorCode::CommonInvalidStructure))?;
-    debug!("Deserialized input_json >>> {:?}", inputs);
+    debug!("Deserialized input_json >>> {:?}", secret!(&inputs));
 
     let outputs: Outputs = serde_json::from_str(&outputs_json).map_err(map_err_err!())
         .or(Err(ErrorCode::CommonInvalidStructure))?;
-    debug!("Deserialized output_json >>> {:?}", outputs);
+    debug!("Deserialized output_json >>> {:?}", secret!(&outputs));
 
     let extra = string_from_char_ptr(extra);
     debug!("Converted extra pointer to string >>> {:?}", extra);
@@ -47,9 +47,9 @@ pub fn deserialize_inputs(
     let extra: Option<Extra> = if let Some(extra_) = extra {
         serde_json::from_str(&extra_).map_err(map_err_err!()).or(Err(ErrorCode::CommonInvalidStructure))?
     } else { None };
-    debug!("Deserialized extra >>> {:?}", extra);
+    debug!("Deserialized extra >>> {:?}", secret!(&extra));
 
-    trace!("logic::build_payment::deserialize_inputs << inputs: {:?}, outputs: {:?}, extra: {:?}", inputs, outputs, extra);
+    trace!("logic::build_payment::deserialize_inputs << inputs: {:?}, outputs: {:?}, extra: {:?}", secret!(&inputs), secret!(&outputs), secret!(&extra));
     return Ok((inputs, outputs, extra, cb));
 }
 
@@ -70,7 +70,7 @@ fn build_payment_request_pointer(
     result: Result<(XferPayload, Option<TaaAcceptance>), ErrorCode>,
 ) -> Result<*const c_char, ErrorCode> {
     let (signed_payload, taa_acceptance) = result?;
-    debug!("Signed payload >>> {:?}", signed_payload);
+    debug!("Signed payload >>> {:?}", secret!(&signed_payload));
 
     if signed_payload.signatures.is_none() {
         error!("Building an unsigned payment request.");

--- a/libsovtoken/src/logic/minting.rs
+++ b/libsovtoken/src/logic/minting.rs
@@ -16,7 +16,7 @@ pub fn deserialize_inputs<'a>(
     extra: *const c_char,
     cb: JsonCallback
 ) -> Result<DeserializedArguments<'a>, ErrorCode> {
-    trace!("logic::minting::deserialize_inputs >> did: {:?}, outputs_json: {:?}, extra: {:?}", did, outputs_json, extra);
+    trace!("logic::minting::deserialize_inputs >> did: {:?}, outputs_json: {:?}, extra: {:?}", secret!(&did), secret!(&outputs_json), secret!(&extra));
     let cb = cb.ok_or(ErrorCode::CommonInvalidStructure)?;
     trace!("Unwrapped callback.");
 
@@ -26,20 +26,20 @@ pub fn deserialize_inputs<'a>(
         }
     );
     let did = opt_res_to_res_opt!(did)?;
-    debug!("Converted did pointer to string >>> {:?}", did);
+    debug!("Converted did pointer to string >>> {:?}", secret!(&did));
 
     let outputs_json = string_from_char_ptr(outputs_json)
         .ok_or(ErrorCode::CommonInvalidStructure)?;
-    debug!("Converted outputs_json pointer to string >>> {:?}", outputs_json);
+    debug!("Converted outputs_json pointer to string >>> {:?}", secret!(&outputs_json));
 
     let outputs: Outputs = serde_json::from_str(&outputs_json)
         .or(Err(ErrorCode::CommonInvalidStructure))?;
-    debug!("Deserialized output_json >>> {:?}", outputs);
+    debug!("Deserialized output_json >>> {:?}", secret!(&outputs));
 
     let extra = string_from_char_ptr(extra);
-    debug!("Deserialized extra >>> {:?}", extra);
+    debug!("Deserialized extra >>> {:?}", secret!(&extra));
 
-    trace!("logic::minting::deserialize_inputs << did: {:?}, outputs: {:?}, extra: {:?}", did, outputs, extra);
+    trace!("logic::minting::deserialize_inputs << did: {:?}, outputs: {:?}, extra: {:?}", secret!(&did), secret!(&outputs), secret!(&extra));
     return Ok((did, outputs, extra, cb));
 }
 
@@ -48,7 +48,7 @@ pub fn build_mint_request(
     mut outputs: Outputs,
     extra: Option<String>,
 ) -> Result<*const c_char, ErrorCode> {
-    trace!("logic::minting::build_mint_request >> did: {:?}, outputs: {:?}", did, outputs);
+    trace!("logic::minting::build_mint_request >> did: {:?}, outputs: {:?}", secret!(&did), secret!(&outputs));
 
     for output in &mut outputs {
         let address = address::unqualified_address_from_address(&output.recipient)?;
@@ -57,7 +57,7 @@ pub fn build_mint_request(
     trace!("Stripped pay:sov: from outputs");
 
     let mint_request = MintRequest::from_config(outputs, did, extra);
-    info!("Built a mint request >>> {:?}", mint_request);
+    info!("Built a mint request >>> {:?}", secret!(&mint_request));
 
     let ptr = mint_request.serialize_to_pointer()
         .or(Err(ErrorCode::CommonInvalidStructure));

--- a/libsovtoken/src/logic/payments.rs
+++ b/libsovtoken/src/logic/payments.rs
@@ -35,7 +35,7 @@ impl<T: CryptoAPI> CreatePaymentHandler<T> {
         trace!("calling self.injected_api.indy_create_key");
         let verkey = self.injected_api.indy_create_key(wallet_id, config)?;
 
-        trace!("got verkey from self.injected_api.indy_create_key {}", verkey);
+        trace!("got verkey from self.injected_api.indy_create_key {}", secret!(&verkey));
         return address::qualified_address_from_verkey(&verkey);
     }
 
@@ -51,7 +51,7 @@ impl<T: CryptoAPI> CreatePaymentHandler<T> {
 
         let cb_closure = move | err: ErrorCode, verkey : String | {
             let res = if ErrorCode::Success == err {
-                trace!("got verkey from self.injected_api.indy_create_key_async {}", verkey);
+                trace!("got verkey from self.injected_api.indy_create_key_async {}", secret!(&verkey));
                 address::qualified_address_from_verkey(&verkey)
             } else {
                 Err(err)

--- a/libsovtoken/src/logic/set_fees.rs
+++ b/libsovtoken/src/logic/set_fees.rs
@@ -36,7 +36,7 @@ pub fn deserialize_inputs<'a>(
     fees_json: *const c_char,
     cb: JsonCallback
 ) -> Result<DeserializedArguments<'a>, ErrorCode> {
-    trace!("logic::set_fees::deserialize_inputs >> did: {:?}, fees_json: {:?}", did, fees_json);
+    trace!("logic::set_fees::deserialize_inputs >> did: {:?}, fees_json: {:?}", secret!(&did), secret!(&fees_json));
     let cb = cb.ok_or(ErrorCode::CommonInvalidStructure)?;
 
     let did = Did::from_pointer(did).map(|did| {

--- a/libsovtoken/src/logic/verify.rs
+++ b/libsovtoken/src/logic/verify.rs
@@ -13,7 +13,7 @@ pub fn deserialize<'a>(
     txo: *const c_char,
     cb: JsonCallback
 ) -> Result<DeserializedArguments<'a>, ErrorCode> {
-    trace!("logic::verify::deserialize >> did: {:?}, txo: {:?}", did, txo);
+    trace!("logic::verify::deserialize >> did: {:?}, txo: {:?}", secret!(&did), secret!(&txo));
     let cb = cb.ok_or(ErrorCode::CommonInvalidStructure)?;
     trace!("Unwrapped callback.");
 
@@ -26,18 +26,18 @@ pub fn deserialize<'a>(
             })
     )?;
 
-    debug!("Converted did pointer to string >>> {:?}", did);
+    debug!("Converted did pointer to string >>> {:?}", secret!(&did));
 
     let txo = string_from_char_ptr(txo)
         .ok_or(ErrorCode::CommonInvalidStructure)?;
-    debug!("Converted txo pointer to string >>> {:?}", txo);
+    debug!("Converted txo pointer to string >>> {:?}", secret!(&txo));
 
     let txo = TXO::from_libindy_string(&txo)
         .map_err(map_err_err!())
         .map_err(|_| ErrorCode::CommonInvalidStructure)?;
     debug!("Deserialized txo: {:?}", txo);
 
-    trace!("logic::verify::deserialize << did: {:?}, txo: {:?}", did, txo);
+    trace!("logic::verify::deserialize << did: {:?}, txo: {:?}", secret!(&did), secret!(&txo));
     Ok((did, txo, cb))
 }
 

--- a/libsovtoken/src/logic/xfer_payload.rs
+++ b/libsovtoken/src/logic/xfer_payload.rs
@@ -206,10 +206,10 @@ trait InputSigner<A: CryptoAPI> {
         cb: Box<Arc<Fn(Result<String, ErrorCode>, String) + Send + Sync>>,
     ) -> Result<(), ErrorCode>
     {
-        trace!("logic::xfer_payload::input_signer::sign_input >> input: {:?}, outputs: {:?}, wallet_handle {:?}", input, outputs, wallet_handle);
+        trace!("logic::xfer_payload::input_signer::sign_input >> input: {:?}, outputs: {:?}, wallet_handle {:?}", secret!(&input), secret!(&outputs), wallet_handle);
         let verkey = address::verkey_from_unqualified_address(&input.address.clone())?;
 
-        debug!("Received verkey for payment address >>> {:?}", verkey);
+        debug!("Received verkey for payment address >>> {:?}", secret!(&verkey));
 
         let vals: Vec<serde_json::Value> = vec![
             Some(json!([input])),
@@ -221,13 +221,13 @@ trait InputSigner<A: CryptoAPI> {
 
         let message = serialize_signature(json!(vals))?;
 
-        debug!("Message to sign >>> {:?}", &message);
+        debug!("Message to sign >>> {:?}", secret!(&message));
 
         let input_key = input.to_string();
 
         let ca = move |signature: Result<String, ErrorCode>| {
             let key = input_key.clone();
-            debug!("Received encoded signature >>> {:?} for input {:?}", signature, key);
+            debug!("Received encoded signature >>> {:?} for input {:?}", secret!(&signature), secret!(&key));
             cb(signature, key);
         };
 

--- a/libsovtoken/src/utils/ffi_support.rs
+++ b/libsovtoken/src/utils/ffi_support.rs
@@ -56,7 +56,6 @@ pub fn c_pointer_from_string(string: String) -> *const c_char {
 */
 pub fn deserialize_from_char_ptr<'a, S: JsonDeserialize<'a>>(str_ptr: *const c_char) -> Result<S, ErrorCode> {
     let json_string = str_from_char_ptr(str_ptr).ok_or(ErrorCode::CommonInvalidStructure)?;
-    println!("deserializing = {:?}",json_string);
 
     let result = S::from_json(json_string).map_err(|_| ErrorCode::CommonInvalidStructure);
     return result;

--- a/libsovtoken/src/utils/macros.rs
+++ b/libsovtoken/src/utils/macros.rs
@@ -52,3 +52,15 @@ macro_rules! rust_slice {
         unsafe { slice::from_raw_parts($x, $y as usize) }
     }
 }
+
+#[cfg(debug_assertions)]
+#[macro_export]
+macro_rules! secret {
+    ($val:expr) => {{ $val }};
+}
+
+#[cfg(not(debug_assertions))]
+#[macro_export]
+macro_rules! secret {
+    ($val:expr) => {{ "_" }};
+}


### PR DESCRIPTION
Introduce macro "secret!" which hides PII information in release version.
If compiled in a debug mode, PII is still being logged.

Signed-off-by: Darko Kulic darko.kulic@evernym.com