### PR TITLE
Prevent rustup update from being run before the target remove logic.

### DIFF
--- a/libsovtoken/build_scripts/ios/mac/mac.01.env.setup.sh
+++ b/libsovtoken/build_scripts/ios/mac/mac.01.env.setup.sh
@@ -26,7 +26,6 @@ if [ "$?" != "0" ]; then
         source $HOME/.cargo/env
         rustup component add rust-src
         rustup component add rust-docs
-        rustup update
         RUSTUP_VERSION=`rustup --version`
         if [ -f /usr/local/bin/rustc.bak ]; then
             sudo mv /usr/local/bin/rustc.bak /usr/local/bin/rustc


### PR DESCRIPTION
Signed-off-by: Devin Smith <devinleighsmith@gmail.com>